### PR TITLE
customEmoji description

### DIFF
--- a/guide/Text/customEmoji.md
+++ b/guide/Text/customEmoji.md
@@ -5,7 +5,7 @@ Sends a custom emoji from the current used server.
 ::: danger
 This function only output emojis from actual used server!
 So make sure that the emoji with the name used is present on the current server. 
-Otherwise, there is an error message.
+Otherwise, nothing is returned.
 :::
 
 #### Usage: `$customEmoji[emoji name]`

--- a/guide/Text/customEmoji.md
+++ b/guide/Text/customEmoji.md
@@ -1,5 +1,12 @@
 # $customEmoji
-Sends a message to a sepecified channel
+Sends a custom emoji from the current used server.
+
+
+::: danger
+This function only output emojis from actual used server!
+So make sure that the emoji with the name used is present on the current server. 
+Otherwise, there is an error message.
+:::
 
 #### Usage: `$customEmoji[emoji name]`
 <br/>


### PR DESCRIPTION
Actual description is from channelSendMessage. Changed it and add a danger field, that it only returns emojis from actual server. Is mandatory that only emojis from the actual server can be returned. Otherwise it will nothing returned.