### PR TITLE
Grammar, quick fixes

### DIFF
--- a/guide/Text/Components/addButton.md
+++ b/guide/Text/Components/addButton.md
@@ -1,12 +1,11 @@
 # $addButton
-adds a button component an existing message,use $button to send a message with a button
+Adds a button to an existing message. Use [$button](./button.md) to send a message with a button.
 
-
-
-#### Usage: `$addButton[Message ID;Label;style/url;link/id;emoji(optional);Adding in new row (yes/no, optional); disabled (yes/no, optional)]`
+## Usage
+`$addButton[Message ID;Label;style/url;link/id;emoji(optional);Add to a new role (yes/no, optional); disabled (yes/no, optional)]`
 <br/>
 
-##### Example
+## Example
 (Add a simple button)
 ![](https://cdn.discordapp.com/attachments/914682255346118687/938578211380543578/Screenshot_20220202202417.jpg)
 (Add in new row)
@@ -14,16 +13,12 @@ adds a button component an existing message,use $button to send a message with a
 (Add disabled)
 ![](https://cdn.discordapp.com/attachments/914682255346118687/938578212018085899/Screenshot_20220202203325.jpg)
 
-::: warning Bug
-Currently the emoji field is not working.
-:::
+:::tip Available colors
+`red, green, blurple, grey, url`
+\
+**URL buttons are grey by default.**
 
-::: tip Available colors
-```
-red, green, blurple, grey, url
-/* url buttons is grey by default */
-```
-* you can use normal unicode emoji,custom emojis,with id,url or $customEmoji[emojiname]
+* You can use normal unicode emojis, custom emojis with their ID, or you can use [$customEmoji](../customEmoji.md).
 :::
 
 ##### Function difficulty: <Badge type="tip" text="Easy" vertical="middle" /> 

--- a/guide/Text/Components/awaitButton.md
+++ b/guide/Text/Components/awaitButton.md
@@ -1,42 +1,43 @@
 # $awaitButton
 Wait a button to be pressed and return its button Id, or `undefined` in case of no button pressed until the timeout.
-::: tip This function supports message curl format
-That way, you can send a message with buttons by using `{button:label:style/url:emoji:id:newline(yes/no)}`
+:::tip Tip
+This function supports the [Message Curl Format](/CodeReferences/ref.message_curl_format.html).
+This way, you can send a message with buttons by using `{button:label:style/url:emoji:id:newline(yes/no)}`.
 :::
 
 #### Usage: `$awaitButton[Message (optional);user id (optional, default:author);timeout (optional, default:15s);button id1 (optional);button id2...]`
 <br/>
-::: details Examples
 
+:::details Examples
 (Simple response)
 
 ![](https://cdn.discordapp.com/attachments/914682255346118687/938556903116652594/Screenshot_20220202190956.jpg)
 
 (Usage example)
 ```
-$let[PressedButton;$awaitbutton[Which color is my favorite?
+$let[pressedButton;$awaitButton[Which color is my favorite?
 {button:Green:GREEN::green}
 {button:Blue:BLUE::blue}
-{button:Red:RED::red};$authorid;15s;red;blue;green]]
+{button:Red:RED::red};$authorID;15s;red;blue;green]]
 /* Saves the pressed button id in a temporary var, so you can retrieve later */
 
-$if[$get[PressedButton]!=red]
+$if[$pressedButton!=red]
 Wrong!
 $else
 Correct!
 $endif
-/* If the button id is different from red, which is the right answer, them incorrect. Else, correct. */
+/* If the button id is different from red, which is the right answer, then incorrect. Else, correct. */
 ```
-choosing something other them red, or nothing.
+Choosing something other them red, or nothing.
 ![](https://cdn.discordapp.com/attachments/914682255346118687/938559970293714984/Screenshot_20220202191954.jpg)
 
-choosing red.
+Choosing red.
 
 ![](https://cdn.discordapp.com/attachments/914682255346118687/938559970792845312/Screenshot_20220202191947.jpg)
 :::
 
-::: tip Note
-You can send embed using [Message Curl Format](../../CodeReferences/ref.message_curl_format.md)
+:::tip Note
+You can send an embed using the [Message Curl Format](/CodeReferences/ref.message_curl_format.md).
 :::
 
 ##### Function difficulty: <Badge type="warning" text="Medium" vertical="middle" /> 

--- a/guide/Text/Components/awaitMenu.md
+++ b/guide/Text/Components/awaitMenu.md
@@ -1,8 +1,8 @@
 # $awaitMenu
 
-To wait for a menu option to be selected and return the selected options values\
-In case of no option selected, it return **undefined**\
-In case of multiple values selected, all of them will return with `,` as seperator
+To wait for a menu option to be selected and return the selected options values.
+If nothing is selected, it returns `undefined`.`
+If multiple values are selected, all of them will be returned, separated with `,`.
 
 ## Usage
 

--- a/guide/Text/Components/buttonEmoji.md
+++ b/guide/Text/Components/buttonEmoji.md
@@ -1,6 +1,6 @@
 # $buttonEmoji
 
-return the clicked button emoji in Button trigger, return undefined if not found
+Return the clicked button's emoji in the [Button trigger](/Trigger/button.html). If there is no emoji, it returns `undefined`.
 
 ## Usage
 

--- a/guide/Text/Components/buttonID.md
+++ b/guide/Text/Components/buttonID.md
@@ -1,6 +1,6 @@
 # $buttonID
 
-return the button ID, return undefined if not found
+Returns the Button ID that triggered the command. Returns `undefined` if the trigger isn't Button.
 
 ## Usage
 

--- a/guide/Text/Components/buttonIsDisabled.md
+++ b/guide/Text/Components/buttonIsDisabled.md
@@ -1,6 +1,7 @@
 # $buttonIsDisabled
 
-return true if button is disabled, false otherwise, return undefined if not found
+Returns true if the button is disabled, otherwise returns `false`.
+<br>If there's no button, return `undefined`.
 
 ## Usage
 

--- a/guide/Text/Components/buttonLabel.md
+++ b/guide/Text/Components/buttonLabel.md
@@ -1,6 +1,6 @@
 # $buttonLabel
 
-return the clicked button label in Button trigger, return undefined if not found
+Return the clicked button's label in the Button trigger. If the button doesn't have a label, return `undefined`.
 
 ## Usage
 

--- a/guide/Text/Components/buttonStyle.md
+++ b/guide/Text/Components/buttonStyle.md
@@ -1,6 +1,6 @@
 # $buttonStyle
 
-return the clicked button style like blurple/red/url in Button trigger, return undefined if not found
+Return the clicked button's style, e.g. `blurple`/`red`/`url` in the Button trigger. If none, `undefined` is returned.
 
 ## Usage
 

--- a/guide/Text/Components/buttonURL.md
+++ b/guide/Text/Components/buttonURL.md
@@ -1,6 +1,6 @@
 # $buttonURL
 
-return the clicked button URL in Button trigger if exists , return undefined if not found
+Return the clicked button's URL in Button trigger if it exists. Else, returns `undefined`` if not found.
 
 ## Usage
 

--- a/guide/Text/Components/disableButton.md
+++ b/guide/Text/Components/disableButton.md
@@ -1,5 +1,5 @@
 # $disableButton
-disables a button by `(Id/label/Emoji/url)`
+Disables a button using its `(ID/label/Emoji/URL)`.
 
 #### Usage: `$disableButton[Message ID;Label/Emoji/URL/ID (optional, default: disables the last button)]`
 

--- a/guide/Text/Components/disableButtons.md
+++ b/guide/Text/Components/disableButtons.md
@@ -1,6 +1,6 @@
 # $disableButtons
 
-Disable buttons in a message, not providing button id will disable every button in the message
+Disable buttons in a message, not providing a Button ID will disable every button in the message.
 
 ## Usage
 

--- a/guide/Text/Components/disableMenu.md
+++ b/guide/Text/Components/disableMenu.md
@@ -1,6 +1,6 @@
 # $disableMenu
 
-Disable a menu(s) in given message, not providing Menu ID will disable every menu in the message
+Disable menus in the given message, not providing a Menu ID will disable every menu in the message.
 
 ## Usage
 

--- a/guide/Text/Components/editButton.md
+++ b/guide/Text/Components/editButton.md
@@ -1,5 +1,5 @@
 # $editButton
-edits an existing button by `(Id/label/Emoji/url)`
+Edits an existing button using its `(ID/label/Emoji/URL)`.
 
 #### Usage: `$editButton[Message ID;Query (optional, default: edit the last button);label/style/emoji/disabled/url/custom_id;New Value]`
 

--- a/guide/Text/Components/editMenu.md
+++ b/guide/Text/Components/editMenu.md
@@ -1,7 +1,7 @@
 # $editMenu
 
-edit a menu in given message\
-type can be: `id/disabled/max/min/placeholder/ph/options
+Edits a menu in given message.\
+`type` can be: `id/disabled/max/min/placeholder/ph/options`.
 
 ## Usage
 

--- a/guide/Text/Components/enableButtons.md
+++ b/guide/Text/Components/enableButtons.md
@@ -1,6 +1,6 @@
 # $enableButtons
 
-Enable buttons in a message, not providing button id will enable every button in the message
+Enable buttons in a message, not providing a Button ID will enable every button in the message.
 
 ## Usage
 

--- a/guide/Text/Components/enableMenu.md
+++ b/guide/Text/Components/enableMenu.md
@@ -1,6 +1,6 @@
 # $enableMenu
 
-enable a menu(s) in given message, not providing Menu ID will enable every menu in the message
+Enables menus in a given message, not providing a Menu ID will enable every menu in the message.
 
 ## Usage
 

--- a/guide/Text/Components/eventSelected.md
+++ b/guide/Text/Components/eventSelected.md
@@ -1,6 +1,6 @@
 # $eventSelected
 
-returns selected values of selectMenus
+Returns values that were selected by the user using [$selectMenu](./selectMenu.md).
 
 ## Usage
 
@@ -9,6 +9,6 @@ $eventSelected or $eventSelected[position;seperator]
 ```
 
 ### For Example:
- $eventSelected would return the first selected value\
- $eventSelected[2] would return the second selected value,since the pos is 2 \
- $eventSelected[;,] would return all selected values seperated by ,
+ `$eventSelected would` return the first selected value.\
+ `$eventSelected[2]` would return the second selected value, since it was the second value clicked by the user.\
+ `$eventSelected[;,]` would return all selected values separated with `,`.

--- a/guide/Text/Components/menuId.md
+++ b/guide/Text/Components/menuId.md
@@ -1,10 +1,10 @@
-# $menuId
+# $menuID
 
-Return the menu id of the menu in [Select Menu Trigger](../../Trigger/menu.md)
+Return the Menu ID of the menu triggered with the [Select Menu Trigger](../../Trigger/menu.md).
 
 ## Usage
 
 ```bash
-$menuId
+$menuID
 ```
 

--- a/guide/Text/Components/removeButton.md
+++ b/guide/Text/Components/removeButton.md
@@ -1,16 +1,16 @@
 # $removeButton
-removes a button from a existing message by `(Id/label/Emoji/url)`
+Removes a button from an existing message using its `(ID/label/Emoji/URL)`.
 
 #### Usage: `$removeButton[Message ID;Label/Emoji/URL/ID (optional, empty means removing the last button)]`
 <br/>
 
-::: details Examples
-(Remove Button by label)
+:::details Examples
+(Remove Button using its label)
 ```
 $removeButton[863xxxxxxxxxx21130;Visit example.com]
 ```
 
-(Remove Last button)
+(Remove the Last button)
 ```
 $removeButton[863xxxxxxxxxx21130]
 ```

--- a/guide/Text/Components/removeButtons.md
+++ b/guide/Text/Components/removeButtons.md
@@ -1,5 +1,5 @@
 # $removeButtons
-will remove multiple buttons from a message by their ids
+Removes multiple buttons from a message using their IDs.
 
 #### Usage: `$removeButtons[Message ID;Button ID1;Button ID2...]`
 <br/>

--- a/guide/Text/Components/removeMenu.md
+++ b/guide/Text/Components/removeMenu.md
@@ -1,6 +1,6 @@
 # $removeMenu
 
-remove a menu(s) in given message, not providing Menu ID will remove every menu in the message
+Removes menus in a given message, not providing a Menu ID will remove every menu in the message.
 
 ## Usage
 

--- a/guide/Text/Components/selectMenu.md
+++ b/guide/Text/Components/selectMenu.md
@@ -1,5 +1,5 @@
 # $selectMenu
-creates a select menu with options
+Creates a Menu with options.
 
 #### Usage: `$selectMenu[id;placeholder;min value(optional);max value;(optional);label;desc;value;value]` works only for one option
 ##### Creating SelectMenu
@@ -7,7 +7,7 @@ Code:
 ```
 $selectMenu[
 {id=id}
-{placeholder=Pls select your anwser!}
+{placeholder=Pls select your answer!}
 {min=1}
 {max=2}
 {label=Option one }
@@ -20,7 +20,7 @@ $selectMenu[
 {emoji=$customEmoji[reject]}
 ]
 ```
-* `id` the id of menu must be unique on multiplie menus
+* `id` the id of menu must be unique on multiple menus
 * `placeholder` 
 * `min` minimum to select (optional)
 * `max` maximum to select (optional)
@@ -30,12 +30,12 @@ $selectMenu[
 * `emoji` emoji for option (optional)
 
 Info:
-* You can have upto 5 menus on a message
+* You can have up to 5 menus on a message
 * You can add maximal 20 options to a menu
-* Id of multplie menus can't be same
+* Id of multiple menus can't be same
 
 ::: tip {key=value} what is this for a syntax?
-This syntax is called curl args.It is really similar to curl message.Especially new Functions support it ,you can use !!func `funcname` to check if it supports curl args.
+This syntax is called curl args.It is really similar to curl message.Especially new Functions support it ,you can use !!func `function name` to check if it supports curl arguments.
  [Learn more](../guide/curl.md)
 :::
 
@@ -43,13 +43,13 @@ Example:
 
 ![](https://i.imgur.com/XbRhFaZ.png)
 
-::: tip Do you want to add a menu inside a Function as paramter like $sendmessage[text]
+::: tip Do you want to add a menu inside a Function as a parameter, like `$sendMessage[text]`?
 
 Use: 
 ```
 {menu:
 {id=id}
-{placeholder=Pls select your anwser!}
+{placeholder=Pls select your answer!}
 {min=1}
 {max=2}
 {label=Option one }

--- a/guide/Text/Math/math.md
+++ b/guide/Text/Math/math.md
@@ -32,7 +32,6 @@ Operator                 | Associativity | Description
 +, -, sqrt               | Right         | Unary prefix operators
 \*, /, %                 | Left          | Multiplication, division, remainder
 +, -                     | Left          | Addition, subtraction
-:::
 
 :::warning Are there any more advanced functions?
 There are more advanced functions located [here.](https://github.com/silentmatt/expr-eval/blob/master/README.md)


### PR DESCRIPTION
This commit modifies all Component documentation pages, fixing grammar.
It also fixed a table I formatted incorrectly in **\$math**.