### PR TITLE
add $httpRequest whitelist note

### DIFF
--- a/guide/Request/httpRequest_ai.md
+++ b/guide/Request/httpRequest_ai.md
@@ -1,6 +1,10 @@
 # $httpRequest
 
-Make HTTP requests with custom content and headers, and retrieve the response.
+Performs a HTTP request, with a content and headers and returns the response content.
+
+::: warning Warning
+In order to use `$httpRequest`, the API you wish to use needs to be whitelisted. To request a whitelist, please open a ticket in our Support Server.
+:::
 
 ## Usage
 


### PR DESCRIPTION
This pull request includes an update to the `guide/Request/httpRequest_ai.md` file to improve clarity and add important usage information for the `$httpRequest` function.

Documentation updates:

* [`guide/Request/httpRequest_ai.md`](diffhunk://#diff-7597da91e20796930f683930b02f9c4b9b4586198e67cb97bb72a3fa634c4d7aL3-R7): Clarified the description of the `$httpRequest` function and added a warning section to inform users about the need for API whitelisting and the process to request it.