### PR TITLE
Fixed $memberJoinedDate broken markdown format

### DIFF
--- a/content/docs/(functions)/Date/memberJoinedDate.mdx
+++ b/content/docs/(functions)/Date/memberJoinedDate.mdx
@@ -6,9 +6,8 @@ Retrieves the date and time a member joined the server. You can specify a user I
 
 #### Usage
 ```cc
-$memberJoinedDate[userID;format(optional)]
+$memberJoinedDate[userID;format(optional)] or $memberJoinedDate
 ``` 
-or `$memberJoinedDate`
 
 *   `userID`: (Optional) The ID of the member you want to retrieve the join date for. If omitted, it will use the command executor's join date.
 *   `format`: (Optional) Specifies whether to return the date or time.  Can be either `date` or `time`. If omitted, it returns the full date and time.

--- a/content/docs/(functions)/Date/memberJoinedDate.mdx
+++ b/content/docs/(functions)/Date/memberJoinedDate.mdx
@@ -7,7 +7,8 @@ Retrieves the date and time a member joined the server. You can specify a user I
 #### Usage
 ```cc
 $memberJoinedDate[userID;format(optional)]
-``` or `$memberJoinedDate`
+``` 
+or `$memberJoinedDate`
 
 *   `userID`: (Optional) The ID of the member you want to retrieve the join date for. If omitted, it will use the command executor's join date.
 *   `format`: (Optional) Specifies whether to return the date or time.  Can be either `date` or `time`. If omitted, it returns the full date and time.


### PR DESCRIPTION
Code blocks
```
like this
```
apparently don't work properly if the rest of a sentence is not started on a new line right after the block ending