### PR TITLE
Replace all `/Other/syntax` to `/Guide/syntax`

### DIFF
--- a/content/docs/(functions)/Text/Components/selectMenu.mdx
+++ b/content/docs/(functions)/Text/Components/selectMenu.mdx
@@ -194,9 +194,9 @@ Use:
 
 <Callout type="error" title={"Please be aware!!"}>
 
-If you add any `:` in this function it will error! Check out [this](/Other/syntax)
+If you add any `:` in this function it will error! Check out [this](/Guide/syntax)
 
-Link escapes are needed, use `\` to escape characters. Read [me](/Other/syntax) to see more
+Link escapes are needed, use `\` to escape characters. Read [me](/Guide/syntax) to see more
 
 </Callout>
 

--- a/content/docs/(functions)/Text/Embed/addField.mdx
+++ b/content/docs/(functions)/Text/Embed/addField.mdx
@@ -62,6 +62,6 @@ Use: `{field:name:value:inline(yes/no default=yes)(optional)}`
 
 <Callout type="error" title={"Please be aware!!"}>
 
-If you add any `:` in this function it will error! Check out [this](/Other/syntax)
+If you add any `:` in this function it will error! Check out [this](/Guide/syntax)
 
 </Callout>

--- a/content/docs/(functions)/Text/Embed/addTimestamp.mdx
+++ b/content/docs/(functions)/Text/Embed/addTimestamp.mdx
@@ -40,6 +40,6 @@ Use: `{timestamp:ms}`
 
 <Callout type="error" title={"Please be aware!!"}>
 
-If you add any `:` in this function it will error! Check out [this](/Other/syntax)
+If you add any `:` in this function it will error! Check out [this](/Guide/syntax)
 
 </Callout>

--- a/content/docs/(functions)/Text/Embed/author.mdx
+++ b/content/docs/(functions)/Text/Embed/author.mdx
@@ -42,6 +42,6 @@ Use: `{author:text:icon url(optional):hyper link(optional)}`
 
 <Callout type="error" title={"Please be aware!!"}>
 
-If you add any `:` in this function it will error! Check out [this](/Other/syntax)
+If you add any `:` in this function it will error! Check out [this](/Guide/syntax)
 
 </Callout>

--- a/content/docs/(functions)/Text/Embed/color.mdx
+++ b/content/docs/(functions)/Text/Embed/color.mdx
@@ -45,6 +45,6 @@ Example: `{color:#0099ff}`
 
 <Callout type="error" title={"Please be aware!!"}>
 
-If you add any `:` in this function it will error! Check out [this](/Other/syntax)
+If you add any `:` in this function it will error! Check out [this](/Guide/syntax)
 
 </Callout>

--- a/content/docs/(functions)/Text/Embed/description.mdx
+++ b/content/docs/(functions)/Text/Embed/description.mdx
@@ -42,6 +42,6 @@ Use: `{description:your text}`
 
 <Callout type="error" title={"Please be aware!!"}>
 
-If you add any `:` in this function it will error! Check out [this](/Other/syntax)
+If you add any `:` in this function it will error! Check out [this](/Guide/syntax)
 
 </Callout>

--- a/content/docs/(functions)/Text/Embed/footer.mdx
+++ b/content/docs/(functions)/Text/Embed/footer.mdx
@@ -29,8 +29,8 @@ Use: `{footer: Your text here:icon url(optional)}`
 
 <Callout type="error" title={"Please be aware!!"}>
 
-If you add any `:` in this function it will error! Check out [this](/Other/syntax)
+If you add any `:` in this function it will error! Check out [this](/Guide/syntax)
 
-Link escapes are needed, use `\` to escape characters. Read [me](/Other/syntax) to see more
+Link escapes are needed, use `\` to escape characters. Read [me](/Guide/syntax) to see more
 
 </Callout>

--- a/content/docs/(functions)/Text/Embed/image.mdx
+++ b/content/docs/(functions)/Text/Embed/image.mdx
@@ -28,8 +28,8 @@ Use: `{image: Your link here}`
 
 <Callout type="error" title={"Please be aware!!"}>
 
-If you add any `:` in this function it will error! Check out [this](/Other/syntax)
+If you add any `:` in this function it will error! Check out [this](/Guide/syntax)
 
-Link escapes are needed, use `\` to escape characters. Read [me](/Other/syntax) to see more
+Link escapes are needed, use `\` to escape characters. Read [me](/Guide/syntax) to see more
 
 </Callout>

--- a/content/docs/(functions)/Text/Embed/thumbnail.mdx
+++ b/content/docs/(functions)/Text/Embed/thumbnail.mdx
@@ -28,8 +28,8 @@ Use: `{thumbnail: Your link here}`
 
 <Callout type="error" title={"Please be aware!!"}>
 
-If you add any `:` in this function it will error! Check out [this](/Other/syntax)
+If you add any `:` in this function it will error! Check out [this](/Guide/syntax)
 
-Link escapes are needed, use `\` to escape characters. Read [me](/Other/syntax) to see more
+Link escapes are needed, use `\` to escape characters. Read [me](/Guide/syntax) to see more
 
 </Callout>

--- a/content/docs/(functions)/Text/Embed/title.mdx
+++ b/content/docs/(functions)/Text/Embed/title.mdx
@@ -40,6 +40,6 @@ Use: `{title: Your title here}`
 
 <Callout type="error" title={"Please be aware!!"}>
 
-If you add any `:` in this function it will error! Check out [this](/Other/syntax)
+If you add any `:` in this function it will error! Check out [this](/Guide/syntax)
 
 </Callout>

--- a/content/docs/Trigger/button.mdx
+++ b/content/docs/Trigger/button.mdx
@@ -55,4 +55,4 @@ In regex ^ and $ are used to match the start and end of the string.
 
 ## More Info
 
-Do you want to know more about the bot's syntax? You can check out [this](/Other/syntax) page to learn more!
+Do you want to know more about the bot's syntax? You can check out [this](/Guide/syntax) page to learn more!

--- a/content/docs/Trigger/time.mdx
+++ b/content/docs/Trigger/time.mdx
@@ -44,4 +44,4 @@ Set a channel used, otherwise errors will not be sent anywhere! This makes bug f
 
 ## More Info
 
-Do you want to know more about the bot's syntax? You can check out [this](/Other/syntax) page to learn more!
+Do you want to know more about the bot's syntax? You can check out [this](/Guide/syntax) page to learn more!

--- a/content/docs/Trigger/voicecondecon.mdx
+++ b/content/docs/Trigger/voicecondecon.mdx
@@ -35,4 +35,4 @@ Set a channel used, otherwise errors will not be sent anywhere! This makes bug f
 
 ## More Info
 
-Do you want to know more about the bot's syntax? You can check out [this](/Other/syntax) page to learn more!
+Do you want to know more about the bot's syntax? You can check out [this](/Guide/syntax) page to learn more!


### PR DESCRIPTION
Because the page `/Other/syntax` was deleted due to being redundant, I found this issue when looking at `$selectMenu`